### PR TITLE
[FIX] GlobalExceptionHandler 충돌 문제 해결

### DIFF
--- a/src/main/java/com/hyomee/clog/common/response/GlobalExceptionHandler.java
+++ b/src/main/java/com/hyomee/clog/common/response/GlobalExceptionHandler.java
@@ -25,7 +25,7 @@ public class GlobalExceptionHandler {
     }
 
     // ⚪ 요청 헤더 누락 예외 처리
-    @ExceptionHandler(Exception.class)
+    @ExceptionHandler(MissingRequestHeaderException.class)
     public ResponseEntity<ApiResponse<Void>> handleMissingHeader(MissingRequestHeaderException e) {
         ErrorCode errorCode = ErrorCode.REQUEST_HEADER_EMPTY;
         return ResponseEntity.status(errorCode.getStatus())


### PR DESCRIPTION
## 연관된 이슈

> close #5

## 작업 내용

> Exception을 처리하는 핸들러 하나로 변경(handleMissingHeader가 MissingRequestHeaderException를 처리하도록 변경)

## 스크린샷 
